### PR TITLE
Fix All Damage Being True Damage

### DIFF
--- a/neoforge/src/main/java/dev/sterner/the_catamount/neoforge/TheCatamountNeoForge.java
+++ b/neoforge/src/main/java/dev/sterner/the_catamount/neoforge/TheCatamountNeoForge.java
@@ -146,7 +146,7 @@ public class TheCatamountNeoForge {
             float newAmount = ModEventHandlers.onLivingDamage(
                     event.getEntity(),
                     event.getSource(),
-                    event.getDamage()
+                    event.getNewDamage()
             );
             event.setNewDamage(newAmount);
         }

--- a/neoforge/src/main/java/dev/sterner/the_catamount/neoforge/TheCatamountNeoForge.java
+++ b/neoforge/src/main/java/dev/sterner/the_catamount/neoforge/TheCatamountNeoForge.java
@@ -146,7 +146,7 @@ public class TheCatamountNeoForge {
             float newAmount = ModEventHandlers.onLivingDamage(
                     event.getEntity(),
                     event.getSource(),
-                    event.getOriginalDamage()
+                    event.getDamage()
             );
             event.setNewDamage(newAmount);
         }


### PR DESCRIPTION
In `TheCatamountNeoForge.GameEvents#onLivingHurt`, it uses `getOriginalAmount` instead of `getAmount`, and then sets the damage to that amount in most cases.  The problem is, the "original amount" is the amount of damage _before modifiers are applied_, so setting it to that results in all damage completely negating the effects of armor, resistance, etc.

This PR changes the `LivingDamageEvent.Pre#getOriginalAmount` call to `#getAmount`, which gives the damage value from before the method is entered, but after armor and resistance have been applied.